### PR TITLE
Add systemd service file

### DIFF
--- a/rsv-core/Makefile
+++ b/rsv-core/Makefile
@@ -5,6 +5,7 @@ bindir := $(prefix)/bin
 initrddir := $(sysconfdir)/rc.d/init.d
 libexecdir := $(prefix)/libexec
 mandir := $(prefix)/share/man
+unitdir := $(prefix)/lib/systemd/system
 python_sitelib := $(shell python -c 'from distutils.sysconfig import get_python_lib; print get_python_lib()')
 
 
@@ -22,9 +23,14 @@ install:
 	install -m 0755 bin/rsv-control $(DESTDIR)/$(bindir)/
 	install -d $(DESTDIR)/$(libexecdir)/rsv
 	cp -rf libexec/misc $(DESTDIR)/$(libexecdir)/rsv/
-	# Install the init script
-	install -d $(DESTDIR)/$(initrddir)
-	install -m 0755 init/rsv.init $(DESTDIR)/$(initrddir)/rsv
+	# Install the init script or systemd service file
+	if which systemctl > /dev/null 2>&1; then \
+		install -d $(DESTDIR)/$(unitdir); \
+		install -m 0644 systemd/rsv.service $(DESTDIR)/$(unitdir)/rsv.service; \
+	else \
+		install -d $(DESTDIR)/$(initrddir); \
+		install -m 0755 init/rsv.init $(DESTDIR)/$(initrddir)/rsv; \
+	fi
 	# Install the configuration
 	install -d $(DESTDIR)/$(sysconfdir)/rsv
 	install -m 0644 etc/consumers.conf $(DESTDIR)/$(sysconfdir)/rsv/

--- a/rsv-core/systemd/rsv.service
+++ b/rsv-core/systemd/rsv.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Resource Service Validator
+After=condor-cron.service
+Wants=condor-cron.service
+
+# needed so shutdown of condor-cron shuts down rsv too
+Requires=condor-cron.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# the sleep 2 is needed to give condor-cron time to start up
+ExecStart=/bin/sh -c '/usr/bin/sleep 2 && /usr/bin/rsv-control --on'
+ExecStop=/usr/bin/rsv-control --off
+
+[Install]
+WantedBy=multi-user.target
+

--- a/rsv-core/systemd/rsv.service
+++ b/rsv-core/systemd/rsv.service
@@ -9,8 +9,11 @@ Requires=condor-cron.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-# the sleep 2 is needed to give condor-cron time to start up
-ExecStart=/bin/sh -c '/usr/bin/sleep 2 && /usr/bin/rsv-control --on'
+
+# give condor-cron some time to start up
+ExecStart=/bin/sh -c '/usr/bin/condor_cron_q > /dev/null 2>&1 || \
+ /usr/bin/sleep 10 && /usr/bin/rsv-control --on'
+
 ExecStop=/usr/bin/rsv-control --off
 
 [Install]


### PR DESCRIPTION
For SOFTWARE-2498. On machines with systemd, replace the init script with a systemd service file.

Some new behavior:
 * starting rsv will now also start condor-cron if condor-cron is stopped
 * stopping/restarting condor-cron will restart rsv if rsv is running