### PR TITLE
avoid parsing unpredictable summary line from condor_cron_q

### DIFF
--- a/rsv-core/init/rsv.init
+++ b/rsv-core/init/rsv.init
@@ -39,11 +39,11 @@ start() {
 status() {
     test -e $REDHAT_LOCKFILE
     lock_status=$?
-    ccq_output=`$CONDOR_EXE_QUEUE rsv 2>&1`
+    ccq_output=`$CONDOR_EXE_QUEUE rsv -af 1`
     ccq_status=$?
-    ccq_summary_line=`echo "$ccq_output" | tail -1`
+    ccq_summary_line=`echo "$ccq_output" | wc -l`
     case $ccq_summary_line in
-        "0 jobs"* ) rsv_jobs_in_queue=N ;;
+        0         ) rsv_jobs_in_queue=N ;;
         *         ) rsv_jobs_in_queue=Y ;;
     esac
 


### PR DESCRIPTION
sorry if this -af thing looks silly - apparently there is not a better
way to get the summary number directly that is 8.4-compatible...