### PR TITLE
fixup for #9 (SOFTWARE-2782)

### DIFF
--- a/rsv-core/init/rsv.init
+++ b/rsv-core/init/rsv.init
@@ -39,9 +39,9 @@ start() {
 status() {
     test -e $REDHAT_LOCKFILE
     lock_status=$?
-    ccq_output=`$CONDOR_EXE_QUEUE rsv -af 1`
+    ccq_output=`$CONDOR_EXE_QUEUE rsv 2>&1`
     ccq_status=$?
-    ccq_summary_line=`echo "$ccq_output" | wc -l`
+    ccq_summary_line=`$CONDOR_EXE_QUEUE rsv -af 1 | wc -l`
     case $ccq_summary_line in
         0         ) rsv_jobs_in_queue=N ;;
         *         ) rsv_jobs_in_queue=Y ;;


### PR DESCRIPTION
There were two things wrong with the first approach:

The "success" condition was supposed to be when ccq_output was empty,
but in that case `echo | wc -l` still returned 1, since echo outputs
an empty line.  Piping the condor_cron_q output directly into wc -l
does the right thing here.

But also, ccq_output gets used in the output messages for diagnostic
purposes, and a list of 1's is not as useful as the default output.