### PR TITLE
collapse java -version output into single line (goc/34406)

### DIFF
--- a/rsv-metrics/libexec/probes/java-version-probe
+++ b/rsv-metrics/libexec/probes/java-version-probe
@@ -143,11 +143,11 @@ def get_java_binary_version(java_binary):
             provider_str = providers[0]
         else:
             provider_str = "(Non-RPM install)"
+        version_output_oneline = version_output.strip().replace('\n', '; ')
         ret = """
-Version: |
-%s
+Version: %s
 Full path: %s
-Provided by: %s""" % (indent_multiline_string(version_output, 2), full_path, provider_str)
+Provided by: %s""" % (version_output_oneline, full_path, provider_str)
         return ret
     else:
         return "(Not found)"


### PR DESCRIPTION
the '|' is causing problems for us when rsv records are joined with pipes, which needs to be fixed elsewhere, for now this should help avoid the issue...

https://ticket.grid.iu.edu/34406