### PR TITLE
SOFTWARE-3021  java-version-probe does not detect tomcat on el7

### DIFF
--- a/rsv-metrics/libexec/probes/worker-scripts/java-version-probe-worker
+++ b/rsv-metrics/libexec/probes/worker-scripts/java-version-probe-worker
@@ -15,8 +15,8 @@ print_tomcat_java () {
     # Tries to determine which Java Tomcat uses
     local tomcatv
     tomcatv=
-    rpm -q tomcat5 &> /dev/null && tomcatv=tomcat5
     rpm -q tomcat6 &> /dev/null && tomcatv=tomcat6
+    rpm -q tomcat &> /dev/null && tomcatv=tomcat
 
     [[ -z $tomcatv ]] && return $E_COMPONENT_NOT_INSTALLED
     (


### PR DESCRIPTION
Per [SOFTWARE-3102](https://jira.opensciencegrid.org/browse/SOFTWARE-3021) I am adding this fix. 

I tested and it worked well:

```
 rsv-control -v 1 -r -u localhost org.osg.general.java-version

Running metric org.osg.general.java-version:

metricName: org.osg.general.java-version
metricType: status
timestamp: 2018-03-05 11:41:25 PST
metricStatus: OK
serviceType: OSG-CE
serviceURI: localhost
gatheredAt: eftest-1.t2.ucsd.edu
summaryData: OK
detailsData: OK: Java packages queried.
---
Installed JRE RPMs:   
  - java-1.7.0-openjdk-1.7.0.141-2.6.10.1.el7_3.x86_64
  - osg-java7-compat-1.0-1.osg33.el7.noarch
  - osg-java7-compat-openjdk-1.0-1.osg33.el7.noarch

java command in path:   
  Version: openjdk version "1.8.0_141"; OpenJDK Runtime Environment (build 1.8.0_141-b16); OpenJDK 64-Bit Server VM (build 25.141-b16, mixed mode)
  Full path: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.141-1.b16.el7_3.x86_64/jre/bin/java
  Provided by: java-1.8.0-openjdk-headless-1.8.0.141-1.b16.el7_3.x86_64

Installed JDK RPMs:   
  - java-1.7.0-openjdk-devel-1.7.0.141-2.6.10.1.el7_3.x86_64
  - osg-java7-devel-compat-1.0-1.osg33.el7.noarch
  - osg-java7-devel-compat-openjdk-1.0-1.osg33.el7.noarch

javac command in path:   
  Version: javac 1.7.0_141
  Full path: /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.141-2.6.10.1.el7_3.x86_64/bin/javac
  Provided by: java-1.7.0-openjdk-devel-1.7.0.141-2.6.10.1.el7_3.x86_64

java used by bestman2: (Not found)

java used by hadoop-0.20: (Not found)

java used by hadoop: (UNKNOWN)

java used by tomcat:   
  Version: openjdk version "1.8.0_141"; OpenJDK Runtime Environment (build 1.8.0_141-b16); OpenJDK 64-Bit Server VM (build 25.141-b16, mixed mode)
  Full path: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.141-1.b16.el7_3.x86_64/jre/bin/java
  Provided by: java-1.8.0-openjdk-headless-1.8.0.141-1.b16.el7_3.x86_64
```
